### PR TITLE
Minor python issues resolved

### DIFF
--- a/demos/python/example1TeBinaryData.py
+++ b/demos/python/example1TeBinaryData.py
@@ -52,8 +52,8 @@ print("For random source, result should be close to 0 bits: %.4f" % teCalc.compu
 # Next, demonstrate how to do this with a numpy array
 teCalc.initialise()
 # Create the numpy arrays:
-sourceNumpy = numpy.array(sourceArray, dtype=numpy.int)
-destNumpy = numpy.array(destArray, dtype=numpy.int)
+sourceNumpy = numpy.array(sourceArray, dtype=int)
+destNumpy = numpy.array(destArray, dtype=int)
 # The above can be passed straight through to JIDT in python 2:
 # teCalc.addObservations(sourceNumpy, destNumpy)
 # But you need to do this in python 3:

--- a/demos/python/example9TeKraskovAutoEmbedding.py
+++ b/demos/python/example9TeKraskovAutoEmbedding.py
@@ -33,7 +33,8 @@ jarLocation = os.path.join(os.getcwd(), "..", "..", "infodynamics.jar");
 if (not(os.path.isfile(jarLocation))):
 	exit("infodynamics.jar not found (expected at " + os.path.abspath(jarLocation) + ") - are you running from demos/python?")
 # Start the JVM (add the "-Xmx" option with say 1024M if you get crashes due to not enough memory space)
-startJVM(getDefaultJVMPath(), "-ea", "-Djava.class.path=" + jarLocation)
+# see: https://jpype.readthedocs.io/en/latest/api.html#jpype.startJVM and https://stackoverflow.com/questions/64841426/duckling-int-argument-must-be-a-string-a-bytes-like-object-or-a-number-not
+startJVM(getDefaultJVMPath(), "-ea", "-Djava.class.path=" + jarLocation, convertStrings=True)
 
 # Examine the heart-breath interaction that Schreiber originally looked at:
 datafile = '../data/SFI-heartRate_breathVol_bloodOx.txt'


### PR DESCRIPTION
There are some minor issues with the example python codes: 
1. a deprecation warning for using `numpy.int()` instead of the suggested native python `int`
2. a TypeError using "old" java Strings. JVM needs an argument to convert these, to work in python 
